### PR TITLE
As the service calls getPs, we need to stub that too.

### DIFF
--- a/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
+++ b/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
@@ -61,11 +61,11 @@ public class TogglePsRefsTest {
         httpApiMockServer.stubFor(get("/v2/ps/810107517681")
            .willReturn(okJson("{\"nationalId\": \"810107517681\","+
                                 "\"nationalIdRef\": \"0016054827\"}")));
-        httpApiMockServer.stubFor(get("/v2/ps/10107583576")
-           .willReturn(okJson("{\"nationalId\": \"10107583576\","+
+        httpApiMockServer.stubFor(get("/v2/ps/810107583576")
+           .willReturn(okJson("{\"nationalId\": \"810107583576\","+
                                 "\"nationalIdRef\": \"016054801\"}")));
-        httpApiMockServer.stubFor(get("/v2/ps/10107518424")
-           .willReturn(okJson("{\"nationalId\": \"10107518424\","+
+        httpApiMockServer.stubFor(get("/v2/ps/810107518424")
+           .willReturn(okJson("{\"nationalId\": \"810107518424\","+
                                 "\"nationalIdRef\": \"016041030\"}")));
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();

--- a/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
+++ b/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
@@ -15,12 +15,9 @@
  */
 package fr.ans.psc.toggle.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import fr.ans.psc.model.Ps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.ans.psc.toggle.ToggleManagerApplication;
@@ -52,13 +49,13 @@ public class TogglePsRefsTest {
     static WireMockExtension httpApiMockServer = WireMockExtension.newInstance().build();
 
     @DynamicPropertySource
-    static void registerPgProperties(DynamicPropertyRegistry propertiesRegistry) {
+    public static void registerPgProperties(DynamicPropertyRegistry propertiesRegistry) {
         propertiesRegistry.add("api.base.url", () -> httpApiMockServer.baseUrl());
     }
 
     @Test
     @DisplayName("should successfully toggle PsRefs")
-    void successfulToggle() {
+    public void successfulToggle() {
         httpApiMockServer.stubFor(put("/v2/toggle")
         .willReturn(aResponse().withStatus(200)));
         httpApiMockServer.stubFor(get("/v2/ps/810107517681")
@@ -83,7 +80,7 @@ public class TogglePsRefsTest {
 
     @Test
     @DisplayName("should handle 4xx return codes")
-    void toggleWithErrors() throws JsonProcessingException {
+    public void toggleWithErrors() {
         httpApiMockServer.stubFor(put("/v2/toggle").withRequestBody(equalToJson(
                 "{\"returnStatus\":100," +
                         "\"nationalIdRef\":\"0016041030\"," +

--- a/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
+++ b/psc-toggle-manager/src/test/java/fr/ans/psc/toggle/service/TogglePsRefsTest.java
@@ -15,9 +15,12 @@
  */
 package fr.ans.psc.toggle.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import fr.ans.psc.model.Ps;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.ans.psc.toggle.ToggleManagerApplication;
@@ -58,6 +61,15 @@ public class TogglePsRefsTest {
     void successfulToggle() {
         httpApiMockServer.stubFor(put("/v2/toggle")
         .willReturn(aResponse().withStatus(200)));
+        httpApiMockServer.stubFor(get("/v2/ps/810107517681")
+           .willReturn(okJson("{\"nationalId\": \"810107517681\","+
+                                "\"nationalIdRef\": \"0016054827\"}")));
+        httpApiMockServer.stubFor(get("/v2/ps/10107583576")
+           .willReturn(okJson("{\"nationalId\": \"10107583576\","+
+                                "\"nationalIdRef\": \"016054801\"}")));
+        httpApiMockServer.stubFor(get("/v2/ps/10107518424")
+           .willReturn(okJson("{\"nationalId\": \"10107518424\","+
+                                "\"nationalIdRef\": \"016041030\"}")));
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         String rootpath = cl.getResource(".").getPath();
@@ -71,7 +83,7 @@ public class TogglePsRefsTest {
 
     @Test
     @DisplayName("should handle 4xx return codes")
-    void toggleWithErrors() {
+    void toggleWithErrors() throws JsonProcessingException {
         httpApiMockServer.stubFor(put("/v2/toggle").withRequestBody(equalToJson(
                 "{\"returnStatus\":100," +
                         "\"nationalIdRef\":\"0016041030\"," +
@@ -95,6 +107,10 @@ public class TogglePsRefsTest {
                         "\"activated\":null," +
                         "\"deactivated\":null}"))
                 .willReturn(aResponse().withStatus(200)));
+      
+       httpApiMockServer.stubFor(get("/v2/ps/810107517681")
+           .willReturn(okJson("{\"nationalId\": \"810107517681\","+
+                                "\"nationalIdRef\": \"0016054827\"}")));
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         String rootpath = cl.getResource(".").getPath();


### PR DESCRIPTION
Closes #10 