### PR TITLE
FIX default configuration with a context path akin to the one used in production.

### DIFF
--- a/psc-toggle-manager/src/main/resources/application.properties
+++ b/psc-toggle-manager/src/main/resources/application.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-server.servlet.context-path=v1
+server.servlet.context-path=/toggle/v1
 api.base.url=http://localhost:9000/api
 
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
Closes #16 
